### PR TITLE
Fix command verify logic

### DIFF
--- a/modules/command-handler.js
+++ b/modules/command-handler.js
@@ -20,7 +20,7 @@ module.exports = function(bot, from, to, message) {
             sendTo = to; // send publicly
         }
 
-        if (!utils.commandExists) {
+        if (!utils.commandExists(command)) {
             bot.say(to, 'It seems like that you type the wrong command.' +
                     'Please type !help ');
             return ;

--- a/utils.js
+++ b/utils.js
@@ -22,11 +22,10 @@ function isChannel(string) {
 }
 
 function commandExists(command) {
-	if (cmdcfg.command) {
+	if (command in cmdcfg) {
 		return true;
 	}
 	return false;
-
 }
 
 function commandEnabled(command) {


### PR DESCRIPTION
- Pass the command string to `commandExists` method.
- Using dot operator to check whether the object has that attribute or
  not won't work as `command` is a string.
